### PR TITLE
Add Full Spotify Integration

### DIFF
--- a/backend/sessions.ts
+++ b/backend/sessions.ts
@@ -4,11 +4,12 @@ import { ObjectRef } from "datex-core-legacy/runtime/pointers.ts";
 export type Item = {
   title: string;
   thumbnail: string;
-  duration: string;
+  duration: number;
   id: string;
   likes: Set<string>;
   liked?: boolean;
   added: number;
+  type : 'youtube' | 'spotify';
 };
 
 export interface Client {
@@ -25,7 +26,14 @@ export interface SessionData {
   queue: Item[];
   recommendedQueue: Item[];
   currentlyPlaying: Item | null;
+  spotifyUnlocked : boolean;
+  spotifyInformation : SpotifyInformation;
 };
+
+export type SpotifyInformation = {
+  codeVerifier : string;
+  accessToken: string;
+}
 
 // map of session codes to session data
 export const sessions = eternalVar('sessions-1234') ?? $$({} as Record<string, SessionData>);
@@ -149,6 +157,12 @@ const createSession = (userId: string) => {
     queue: [] as Item[],
     recommendedQueue: [] as Item[],
     currentlyPlaying: null as Item | null,
+    spotifyUnlocked :false,
+    spotifyInformation : {
+      codeVerifier : '',
+      accessToken: ' ',
+    } as SpotifyInformation
+
   };
   sessions[code] = session;
 

--- a/common/client.tsx
+++ b/common/client.tsx
@@ -1,6 +1,6 @@
 import { QueueItem } from "./components/QueueItem.tsx";
 import SearchBar from "./components/SearchBar.tsx";
-import { search } from "backend/data.tsx";
+import { searchSpotify, searchYoutube } from "backend/data.tsx";
 import { updateUser, getSortedQueue, Item } from "backend/sessions.ts";
 import { Context } from "uix/routing/context.ts";
 import { loadInitialTheme } from "./components/ToggleThemeButton.tsx";
@@ -33,7 +33,14 @@ export default async function App(ctx: Context) {
     showSearch.val = true;
 
     searchResults.splice(0, searchResults.length);
-    searchResults.push(...(await search(value)));
+
+    if(session.spotifyUnlocked && session.spotifyInformation.accessToken!=' ') {
+			console.log("searched spotify" + session.spotifyInformation.accessToken);
+			searchResults.push(...await searchSpotify(value, session.spotifyInformation.accessToken));
+				
+		}
+
+    searchResults.push(...(await searchYoutube(value)));
   };
 
   const menu = always(() => {

--- a/common/components/QueueItem.tsx
+++ b/common/components/QueueItem.tsx
@@ -5,7 +5,6 @@ import { getRecommendations, updateRecommendations  } from "backend/data.tsx"
 
 const userId = (await getUserId()).userId;
 
-const userId = (await getUserId()).userId;
 
 export async function QueueItem({
   item,
@@ -13,8 +12,9 @@ export async function QueueItem({
   code
 }: Readonly<{ item: ObjectRef<Item>; type: QueueType; code: string }>) {
 
+  const session = await getSessionWithCode(code);
   async function renderIcon() {
-    const session = await getSessionWithCode(code);
+    
     if (!session) return null;
 
     if (session.queue.some((v) => v.id == item.id) || session.currentlyPlaying?.id == item.id) {
@@ -174,6 +174,15 @@ export async function QueueItem({
     }
   }
 
+  function parseTime (inputSeconds:number) {
+    const minutes = Math.floor(inputSeconds / 60).toString();
+    const seconds = inputSeconds % 60;
+    let printseconds = seconds.toString();
+    if(seconds < 10) printseconds = "0"+seconds.toString(); 
+    return minutes + ":" + printseconds;
+  }
+
+  const showType = $$(session.spotifyUnlocked);
   return (
     <div class="queueframe w-full rounded-xl bg-white dark:bg-white/5 border border-black dark:border-white/10 h-20 overflow-hidden mb-2 ">
       <div class="queueitem text-black dark:text-white flex items-left h-full">
@@ -181,11 +190,13 @@ export async function QueueItem({
         <div class="flex flex-1 flex-grow justify-between">
           <div class="pl-4 justify-center flex flex-col h-full">
             <p class="line-clamp-2 font-bold text-md leading-6">{item.title}</p>
-            <p class="text-xs">{item.duration} minutes</p>
+            <p class="text-xs">{parseTime(item.duration)} minutes</p>
+            {toggle(showType,<p class="text-xs">{item.type}</p>) }
           </div>
           <div class="queueicon2 flex h-full justify-center items-center stroke-black dark:stroke-white px-2">
             {await getAction()}
           </div>
+
         </div>
       </div>
     </div>

--- a/common/components/VideoPlayer.tsx
+++ b/common/components/VideoPlayer.tsx
@@ -1,31 +1,85 @@
-import { getAndRemoveNextVideoFromSession, Item } from "backend/sessions.ts";
+import { getAndRemoveNextVideoFromSession, Item, getSessionWithCode } from "backend/sessions.ts";
 
-export default function VideoPlayer({ queue, code }: Readonly<{ queue: Item[], code: string }>) {
+export default function VideoPlayer({ queue, code, access_token }: Readonly<{ queue: Item[], code: string , access_token : string}>) {
   // @ts-ignore - YouTube API
-  let player;
+  let youtubePlayer;
+  //@ts-ignore Spotify API
+  let spotifyPlayer;
+  let spotifyDeviceID = '';
 
-  async function playNext() {
-    // @ts-ignore - YouTube API
-    if (!player || player.getPlayerState() !== YT.PlayerState.PLAYING) {
-      const video = await getAndRemoveNextVideoFromSession(code);
-      if (video) {
-        play(video.id);
-      }
-    }
+  if(access_token != " ") {
+    const spotifyPlayerElement = document.createElement('script');
+    spotifyPlayerElement.src = "https://sdk.scdn.co/spotify-player.js";
+    document.body.appendChild(spotifyPlayerElement);
   }
 
-  function play(videoId: string) {
+  const isYoutubePlayer = $$(true);
+  const spotifyImage = $$('')
+
+  const youtubePlayerElement = document.createElement("script");
+  youtubePlayerElement.src = "https://www.youtube.com/iframe_api";
+  document.body.appendChild(youtubePlayerElement);
+  
+  // @ts-ignore - YouTube API
+  globalThis.onYouTubeIframeAPIReady = ()=>{};
+  // @ts-ignore Spotify API
+  globalThis.onSpotifyWebPlaybackSDKReady = ()=> {
+    //@ts-ignore Spotify API
+    if (spotifyPlayer) return;
+        //@ts-ignore Spotify API
+    spotifyPlayer = new window.Spotify.Player({
+      name: 'UIXSpotifyPlayer',
+      //@ts-ignore Spotify API
+      getOAuthToken : cb => {cb(access_token)},
+      volume: 0.5,
+    });
+
+    //@ts-ignore Spotify API
+    spotifyPlayer.on("ready", ({device_id}) => {
+      spotifyDeviceID = device_id;
+    });
+
+    //@ts-ignore Spotify API
+    spotifyPlayer.on("player_state_changed", state => onStateChangeSpotify(state))
+
+    spotifyPlayer.connect();
+  }
+
+   const playNext = async  () => {
     // @ts-ignore - YouTube API
-    if (player) {
-      player.loadVideoById(videoId);
+    if(spotifyPlayer) spotifyPlayer.pause()
+     // @ts-ignore - YouTube API
+    //youtubePlayer.stopVideo()
+
+    const video = await getAndRemoveNextVideoFromSession(code);
+      
+    if (!video) return;
+    
+    
+    if (video.type == 'youtube') {
+      isYoutubePlayer.val = true;   
+      playYoutube(video.id);
+    
+    } else {
+           
+      isYoutubePlayer.val = false;
+      playSpotify(video.id,video.thumbnail);
+    }
+    
+  }
+
+  function playYoutube(videoId: string) {
+    // @ts-ignore - YouTube API
+    if (youtubePlayer) {
+      youtubePlayer.loadVideoById(videoId);
     } else {
       // @ts-ignore - YouTube API
-      player = new window.YT.Player("player", {
+      youtubePlayer = new window.YT.Player("player", {
         height: "315",
         width: "560",
         videoId: videoId,
         events: {
-          onStateChange: onStateChange,
+          onStateChange: onStateChangeYoutube,
         },
         playerVars: {
           autoplay: 1,
@@ -41,8 +95,30 @@ export default function VideoPlayer({ queue, code }: Readonly<{ queue: Item[], c
     }
   }
 
+  
+  async function playSpotify(trackId:string, thumbnail:string){
+    spotifyImage.val = thumbnail;
+    
+    //@ts-ignore Spotify API 
+    if(spotifyPlayer) {      
+      
+      const response = await fetch('https://api.spotify.com/v1/me/player/play?device_id=' + spotifyDeviceID, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: 'Bearer '+ access_token,
+        },
+        body: JSON.stringify({
+          uris: ['spotify:track:'+ trackId],
+          position_ms: 0,
+      })
+    })
+    console.log(response.json());
+
+  }}
+
   // @ts-ignore - YouTube API
-  function onStateChange(event) {
+  function onStateChangeYoutube(event) {
     // @ts-ignore - YouTube API
     if (event.data === window.YT.PlayerState.ENDED) {
       setTimeout(() => {
@@ -51,16 +127,15 @@ export default function VideoPlayer({ queue, code }: Readonly<{ queue: Item[], c
     }
   }
 
-  function onYouTubeIframeAPIReady() {
-    playNext();
+  //@ts-ignore Spotify API
+  function onStateChangeSpotify(state) {
+        
+    if (state.paused && state.position === 0) {
+      setTimeout(() => {
+        playNext(); 
+      }, 200);}
   }
 
-  const tag = document.createElement("script");
-  tag.src = "https://www.youtube.com/iframe_api";
-  document.body.appendChild(tag);
-
-  // @ts-ignore - YouTube API
-  globalThis.onYouTubeIframeAPIReady = onYouTubeIframeAPIReady;
 
   const text = always(() => {
     if (queue.length === 0) {
@@ -70,65 +145,29 @@ export default function VideoPlayer({ queue, code }: Readonly<{ queue: Item[], c
   })
 
   return (
+    <div class = "relative w-full">
     <div class="relative aspect-video bg-white dark:bg-white/5 border border-black dark:border-white/10 w-full overflow-hidden object-cover rounded-xl">
-      <div
+      {toggle(isYoutubePlayer,<div
         id="player"
         class="w-full h-full flex items-center justify-center dark:text-white text-black font-semibold"
       >
         {text}
+      </div>,
+      <div class="h-full w-full items-center justify-center object-cover">
+        <img id="spotifyImage" src={spotifyImage} alt="" />
       </div>
+      )}
+
+    
+    </div>
+    <div class="rounded-full bg-white dark:bg-white/5 border border-black dark:border-white/10" > 
+    <button onclick={playNext} >
+      
+      play/ Next
+    </button>
+    </div>
+    
+    
     </div>
   );
 }
-
-
-/*
-  let ytplayer;
-  let spotplayer;
-  const script = document.createElement("script");
-  script.src = "https://sdk.scdn.co/spotify-player.js";
-  script.async = true;
-  document.body.appendChild(script);
-  function play2(id: string, type: string) {
-    if (type === "youtube") {
-      if (ytplayer) {
-        player.loadVideoById(id);
-      } else {
-        player = new window.YT.Player("ytplayer", {
-          height: "315",
-          width: "560",
-          videoId: id,
-          events: {
-            onStateChange: onStateChange,
-          },
-          playerVars: {
-            autoplay: 1,
-            color: "white",
-            controls: 0,
-            disablekb: 1,
-            iv_load_policy: 3,
-            modestbranding: 1,
-            rel: 0,
-            showinfo: 0,
-          },
-        });
-      }
-    } else if (type === "spotify") {
-      if (spotplayer) {
-        fetch(`https://api.spotify.com/v1/me/player/play`, {
-          method: "PUT",
-          body: JSON.stringify({ uris: [`spotify:track:${id}`] }),
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${accessToken}`,
-          },
-        }) else {
-            player = new Spotify.Player({
-                name: 'Web Playback SDK',
-                getOAuthToken: cb => { cb(accessToken); },
-                volume: 0.5
-            })
-        }};
-      }
-    } 
-*/

--- a/common/helper.tsx
+++ b/common/helper.tsx
@@ -1,11 +1,11 @@
-export default function addDurations(duration1: string, duration2: string) {
+export default function addDurations(duration1: string, duration2: number) {
   const duration1Partitions = duration1.split(":").map(Number);
-  const duration2Partitions = duration2.split(":").map(Number);
+  //const duration2Partitions = duration2.split(":").map(Number);
   const duration1Seconds = duration1Partitions[0] * 60 + duration1Partitions[1];
-  const duration2Seconds = duration2Partitions[0] * 60 + duration2Partitions[1];
-  const totalSeconds = duration1Seconds + duration2Seconds;
-  const minutes = Math.floor(totalSeconds / 60);
-  let seconds = totalSeconds % 60;
-  seconds = seconds < 10 ? "0" + seconds : seconds;
-  return `${minutes}:${seconds}`;
+  //const duration2Seconds = duration2Partitions[0] * 60 + duration2Partitions[1];
+  const totalSeconds = duration1Seconds + duration2;
+  const minutes = Math.floor(totalSeconds / 60).toString();
+  const seconds = totalSeconds % 60;
+  const printSeconds = seconds < 10 ? "0" + seconds.toString() : seconds.toString();
+  return minutes+ ":" + printSeconds;
 }

--- a/common/page.tsx
+++ b/common/page.tsx
@@ -5,7 +5,7 @@ import { QueueItem } from "./components/QueueItem.tsx";
 
 import QRCodeOverlay from "./components/QRCodeOverlay.tsx";
 import UserDisplay from "./components/UserDisplay.tsx";
-import { getSessionUserHosts, getSortedQueue, getRecommendedQueue } from "backend/sessions.ts";
+import { Item, getSessionUserHosts, getSortedQueue, getRecommendedQueue } from "backend/sessions.ts";
 
 import { NowPlaying } from "./components/NowPlaying.tsx";
 import addDurations from "./helper.tsx";
@@ -13,7 +13,11 @@ import addDurations from "./helper.tsx";
 import ToggleThemeButton, {
   loadInitialTheme,
 } from "./components/ToggleThemeButton.tsx";
-import { Item } from "../backend/sessions.ts";
+
+import {generateRandomString, sha256, base64encode, authorizeSpotify, getAccessToken } from "../common/spotifyHelper.tsx"
+
+//import {playNext} from "common/components/VideoPlayer.tsx"
+
 
 export default async function App() {
   const session = await getSessionUserHosts();
@@ -22,7 +26,7 @@ export default async function App() {
 
   const arr = Array.from(session.clientIds);
   const num = arr.length;
-  console.log(arr);
+  //console.log(arr);
 	const users = Object.values(session.clients).map(client => client.name);
 	console.log(users);
 
@@ -75,6 +79,27 @@ export default async function App() {
 
 	}
 
+  const CLIENT_ID = '87684034f00b4534b87af30e3b582d09';
+	const CLIENT_REDIRECT = 'http://localhost/player';
+	
+  if (session.spotifyInformation.codeVerifier == '')  {
+		session.spotifyInformation.codeVerifier = generateRandomString(64);
+    
+	}
+  const hashed = await sha256(session.spotifyInformation.codeVerifier);
+	const codeChallenge = base64encode(hashed);
+
+  const urlParams = new URLSearchParams(window.location.search);
+	const spotify_code  = urlParams.get('code');
+	
+  if (spotify_code && !session.spotifyUnlocked){
+    session.spotifyInformation.accessToken = await getAccessToken(session.spotifyInformation.codeVerifier, spotify_code, CLIENT_ID,CLIENT_REDIRECT);
+    session.spotifyUnlocked = true;
+  }
+	console.log(session.spotifyInformation)
+	//session.spotifyInformation.codeVerifier ="";
+
+	const unlock = $$(session.spotifyUnlocked);
   return (
     <main class="w-screen h-screen relative bg-gray-50 dark:bg-gray-950">
       <div class="mx-auto grid md:grid-cols-2 h-screen">
@@ -99,10 +124,24 @@ export default async function App() {
         
         <div class="flex flex-col overflow-y-hidden h-screen bg-white dark:bg-white/5 border border-black dark:border-white/10 rounded-xl">
           <div class="flex px-8 mx-0 mt-8 mb-4">
-            <VideoPlayer queue={session.queue} code={code} />
+            <VideoPlayer queue={session.queue} code={code} access_token={session.spotifyInformation.accessToken} />
           </div>
           <div class="flex items-center justify-end px-12 h-10 mb-4">
             <ToggleThemeButton />
+          <div class = "rounded-full bg-white dark:bg-white/5 border border-black dark:border-white/10 dark:text-white"> 
+          {toggle ( unlock, 
+          
+            <p class="mb-2 font-bold">Spotify was unlocked</p>,
+          
+            <button class="fo" onclick={()=>authorizeSpotify(CLIENT_ID, CLIENT_REDIRECT, codeChallenge)}>
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-spotify" viewBox="0 0 16 16">
+              <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0m3.669 11.538a.5.5 0 0 1-.686.165c-1.879-1.147-4.243-1.407-7.028-.77a.499.499 0 0 1-.222-.973c3.048-.696 5.662-.397 7.77.892a.5.5 0 0 1 .166.686m.979-2.178a.624.624 0 0 1-.858.205c-2.15-1.321-5.428-1.704-7.972-.932a.625.625 0 0 1-.362-1.194c2.905-.881 6.517-.454 8.986 1.063a.624.624 0 0 1 .206.858m.084-2.268C10.154 5.56 5.9 5.419 3.438 6.166a.748.748 0 1 1-.434-1.432c2.825-.857 7.523-.692 10.492 1.07a.747.747 0 1 1-.764 1.288"/>
+            </svg>
+              <p class="mb-2 font-bold">Log into Spotify</p>
+            </button>
+           
+            )}
+          </div>
           </div>
 
           {current}

--- a/common/spotifyHelper.tsx
+++ b/common/spotifyHelper.tsx
@@ -1,0 +1,70 @@
+import { getSessionWithCode, sessions } from "backend/sessions.ts";
+
+
+
+export const generateRandomString = (length:number) => {
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    const values = crypto.getRandomValues(new Uint8Array(length));
+    return values.reduce((acc, x) => acc + possible[x % possible.length], "");
+    }
+    
+  export const sha256 = (plain : string) => {
+    const encoder = new TextEncoder()
+    const data = encoder.encode(plain)
+    return window.crypto.subtle.digest('SHA-256', data)
+  }
+  
+  //@ts-ignore input type
+  export const base64encode = (input) => {
+    return btoa(String.fromCharCode(...new Uint8Array(input)))
+      .replace(/=/g, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+    }
+   
+  export const  authorizeSpotify = (clientID :string, clientRedirect :string, codeChallenge:string) => {
+    const auth_query_parameters = new URLSearchParams({
+      response_type: "code",
+      client_id: clientID,
+      scope: "streaming \
+               user-read-email \
+               user-read-private",
+      redirect_uri: clientRedirect,
+      code_challenge_method: 'S256',
+      code_challenge: codeChallenge,
+     
+      })
+        
+    const authUrl = 'https://accounts.spotify.com/authorize/?' + auth_query_parameters.toString();
+    redirect(authUrl);
+    }
+  
+    export const  getAccessToken = async (codeVerifier :string, spotifyCode:string, clientID : string, clientRedirect:string )=>{
+      console.log("getting token")
+      //const session = getSessionWithCode(sessionCode);
+      //console.log(session.spotifyInformation);
+      
+      
+          
+      const payload = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code : spotifyCode as string,
+          redirect_uri: clientRedirect,
+          client_id: clientID,
+          code_verifier: codeVerifier as string, 
+        }),
+      }	
+    
+      let accessToken =""
+      const body = await fetch('https://accounts.spotify.com/api/token', payload);
+      const response = await body.json().then((r) => accessToken = r.access_token );
+      
+      console.log(response.access_token);
+      
+      return accessToken
+      }

--- a/frontend/entrypoint.css
+++ b/frontend/entrypoint.css
@@ -871,10 +871,12 @@ select {
   margin-top: 1rem;
 }
 
-.mt-6 {
-  margin-top: 1.5rem;
 .mt-5 {
   margin-top: 1.25rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
 }
 
 .mt-8 {
@@ -1063,12 +1065,12 @@ select {
   gap: 2.5rem;
 }
 
-.gap-4 {
-  gap: 1rem;
-}
-
 .gap-3 {
   gap: 0.75rem;
+}
+
+.gap-4 {
+  gap: 1rem;
 }
 
 .gap-6 {


### PR DESCRIPTION
For any Play Session, on the Host Laptop, someone can sign into their Spotify Premium account. From the point that this has happened, any Party Guest can also search for Song in Spotify on their device. Songs now have a Type associated with them, whivh is used to determine the Type of Player to ply the song with. If Spotify was unlocked for the party, a Spotify player element is created and added to the dom, Spotify songs are played  throught that. As this is only an audio player, there is currently no proper view for Spotify songs, instead the album cover is simply displayed. 

Todo:
1. Style the login Button
2. Fix A bug, where if a Spotify song is played right after another, it pulls two songs from the queue and potentially plays a Spotify song and a YouTube video at the same time. 
3. Find a way to order Spotify and YouTube songs in the search window. Currently Spotify songs are added first, the YouTube videos are appended to the list. 
4. Maybe add universal playback controls. There is a button which plays the next song, but volume control would be a neat addition. 
